### PR TITLE
Update type for callback parameters

### DIFF
--- a/normalizer.tz
+++ b/normalizer.tz
@@ -1,4 +1,4 @@
-parameter (or (pair %get string (contract nat)) (big_map %update string (pair timestamp (pair timestamp (pair nat (pair nat (pair nat (pair nat nat))))))));
+parameter (or (pair %get string (contract (pair string nat))) (big_map %update string (pair timestamp (pair timestamp (pair nat (pair nat (pair nat (pair nat nat))))))));
 storage   (pair (pair (list %assetCodes string) (big_map %assetMap string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))))) (pair (int %numDataPoints) (address %oracleContract)));
 code
   {
@@ -13,40 +13,44 @@ code
         SWAP;       # @parameter%get : string : @storage
         DUP;        # @parameter%get : @parameter%get : string : @storage
         DUG 2;      # @parameter%get : string : @parameter%get : @storage
-        CDR;        # contract nat : string : @parameter%get : @storage
-        DIG 3;      # @storage : contract nat : string : @parameter%get
-        DUP;        # @storage : @storage : contract nat : string : @parameter%get
-        DUG 4;      # @storage : contract nat : string : @parameter%get : @storage
-        CADR;       # big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : contract nat : string : @parameter%get : @storage
-        DIG 2;      # string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : contract nat : @parameter%get : @storage
-        DUP;        # string : string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : contract nat : @parameter%get : @storage
-        DUG 3;      # string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : contract nat : string : @parameter%get : @storage
-        MEM;        # bool : contract nat : string : @parameter%get : @storage
+        CDR;        # contract (pair string nat) : string : @parameter%get : @storage
+        DIG 3;      # @storage : contract (pair string nat) : string : @parameter%get
+        DUP;        # @storage : @storage : contract (pair string nat) : string : @parameter%get
+        DUG 4;      # @storage : contract (pair string nat) : string : @parameter%get : @storage
+        CADR;       # big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : contract (pair string nat) : string : @parameter%get : @storage
+        DIG 2;      # string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : contract (pair string nat) : @parameter%get : @storage
+        DUP;        # string : string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : contract (pair string nat) : @parameter%get : @storage
+        DUG 3;      # string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : contract (pair string nat) : string : @parameter%get : @storage
+        MEM;        # bool : contract (pair string nat) : string : @parameter%get : @storage
         IF
           {
-            DIG 2;      # @parameter%get : contract nat : string : @storage
-            DROP;       # contract nat : string : @storage
+            DIG 2;      # @parameter%get : contract (pair string nat) : string : @storage
+            DROP;       # contract (pair string nat) : string : @storage
           }
           {
-            UNIT;       # unit : contract nat : string : @parameter%get : @storage
+            UNIT;       # unit : contract (pair string nat) : string : @parameter%get : @storage
             FAILWITH;   # FAILED
-          }; # contract nat : string : @storage
-        NIL operation; # list operation : contract nat : string : @storage
-        SWAP;       # contract nat : list operation : string : @storage
-        PUSH mutez 0; # mutez : contract nat : list operation : string : @storage
-        DIG 4;      # @storage : mutez : contract nat : list operation : string
-        DUP;        # @storage : @storage : mutez : contract nat : list operation : string
-        DUG 5;      # @storage : mutez : contract nat : list operation : string : @storage
-        CADR;       # big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract nat : list operation : string : @storage
-        DIG 4;      # string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract nat : list operation : @storage
-        GET;        # option (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract nat : list operation : @storage
+          }; # contract (pair string nat) : string : @storage
+        NIL operation; # list operation : contract (pair string nat) : string : @storage
+        SWAP;       # contract (pair string nat) : list operation : string : @storage
+        PUSH mutez 0; # mutez : contract (pair string nat) : list operation : string : @storage
+        DIG 4;      # @storage : mutez : contract (pair string nat) : list operation : string
+        DUP;        # @storage : @storage : mutez : contract (pair string nat) : list operation : string
+        DUG 5;      # @storage : mutez : contract (pair string nat) : list operation : string : @storage
+        CADR;       # big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract (pair string nat) : list operation : string : @storage
+        DIG 4;      # string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract (pair string nat) : list operation : @storage
+        DUP;        # string : string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract (pair string nat) : list operation : @storage
+        DUG 5;      # string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract (pair string nat) : list operation : string : @storage
+        GET;        # option (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract (pair string nat) : list operation : string : @storage
         IF_SOME
           {}
           {
-            UNIT;       # unit : mutez : contract nat : list operation : @storage
+            UNIT;       # unit : mutez : contract (pair string nat) : list operation : string : @storage
             FAILWITH;   # FAILED
-          }; # @some : mutez : contract nat : list operation : @storage
-        CAAR;       # nat : mutez : contract nat : list operation : @storage
+          }; # @some : mutez : contract (pair string nat) : list operation : string : @storage
+        CAAR;       # nat : mutez : contract (pair string nat) : list operation : string : @storage
+        DIG 4;      # string : nat : mutez : contract (pair string nat) : list operation : @storage
+        PAIR;       # pair string nat : mutez : contract (pair string nat) : list operation : @storage
         TRANSFER_TOKENS; # operation : list operation : @storage
         CONS;       # list operation : @storage
       }


### PR DESCRIPTION
This PR changes the callback type from the Normalizer's `get` method from `nat` to `Pair(string, nat)`. The previous callback contained a price only, the new callback contains a pair with the asset code and the price. 

This fixes an edge case where a malicious user could push price data to a contract by using an alternative asset. Attaching the asset code to the request allows client contracts to differentiate in this case. 

This PR does a few things:
- Updates core logic as described above
- Explicitly sets the input parameter's type in smartpy using `sp.set_type` to improve readability / useability
- Updates tests. Additionally, modifies the successful case to capture the data returned and validate it, which provides stronger guarantees on 
- Runs `compile_smartpy.sh` to prove tests pass and produce a new `normalizer.tz` file. 

Additional considerations:
- This is technically a breaking change. We could leave the existing endpoint in place with the same API and a strong warning, but given that Harbinger is only a few weeks old I think it is reasonable to make a breaking change. 

Future Tasks:
- If accepted, we'll need to cut a new version of `harbinger-lib` and `harbinger-cli` which export this new contract
- We should re-deploy the testnet / mainnet normalizers and update the posting infrastructure Blockscale is running
- We should have some comms strategy for community projects who might be prototyping with this data