### PR TITLE
Return timestamp in `get`

### DIFF
--- a/normalizer.py
+++ b/normalizer.py
@@ -132,9 +132,10 @@ class NormalizerContract(sp.Contract):
 
     # Returns the data in the Normalizer for the given asset.
     #
-    # The data returned takes the form of Pair(String, Pair(Timestamp, Nat)), where the values are
-    # the asset code requested, the time of the latest candle used to compute the update, and the 
-    # normalized price for the asset.
+    # The data returned takes the form of Pair(String, Pair(Timestamp, Nat)), where the following components:
+    # - The asset code requested
+    # - The time of the latest candle that was used to compute the update
+    # - The normalized price of the asset. 
     #
     # The normalized value is represented as a natural number with six
     # digits of precision. For instance $123.45 USD would be represented

--- a/normalizer.py
+++ b/normalizer.py
@@ -20,8 +20,6 @@ fifoDT = FifoQueue.FifoDataType()
 # The normalized value is represented as a natural number with six
 # digits of precision. For instance $123.45 USD would be represented
 # as 123_450_000.
-#
-# Normalizers keep track of a timestamp which tracks the last time an update was pushed. 
 #####################################################################
 
 class NormalizerContract(sp.Contract):

--- a/normalizer.py
+++ b/normalizer.py
@@ -64,7 +64,7 @@ class NormalizerContract(sp.Contract):
                 assetMap=assetMap,
                 assetCodes=assetCodes,
                 oracleContract=oracleContractAddress,
-                numDataPoints=numDataPoints,
+                numDataPoints=numDataPoints
                 )
 
     # Update the Normalizer contract with a new set of data points.

--- a/normalizer.tz
+++ b/normalizer.tz
@@ -1,4 +1,4 @@
-parameter (or (pair %get string (contract (pair string nat))) (big_map %update string (pair timestamp (pair timestamp (pair nat (pair nat (pair nat (pair nat nat))))))));
+parameter (or (pair %get string (contract (pair string (pair timestamp nat)))) (big_map %update string (pair timestamp (pair timestamp (pair nat (pair nat (pair nat (pair nat nat))))))));
 storage   (pair (pair (list %assetCodes string) (big_map %assetMap string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))))) (pair (int %numDataPoints) (address %oracleContract)));
 code
   {
@@ -13,44 +13,60 @@ code
         SWAP;       # @parameter%get : string : @storage
         DUP;        # @parameter%get : @parameter%get : string : @storage
         DUG 2;      # @parameter%get : string : @parameter%get : @storage
-        CDR;        # contract (pair string nat) : string : @parameter%get : @storage
-        DIG 3;      # @storage : contract (pair string nat) : string : @parameter%get
-        DUP;        # @storage : @storage : contract (pair string nat) : string : @parameter%get
-        DUG 4;      # @storage : contract (pair string nat) : string : @parameter%get : @storage
-        CADR;       # big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : contract (pair string nat) : string : @parameter%get : @storage
-        DIG 2;      # string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : contract (pair string nat) : @parameter%get : @storage
-        DUP;        # string : string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : contract (pair string nat) : @parameter%get : @storage
-        DUG 3;      # string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : contract (pair string nat) : string : @parameter%get : @storage
-        MEM;        # bool : contract (pair string nat) : string : @parameter%get : @storage
+        CDR;        # contract (pair string (pair timestamp nat)) : string : @parameter%get : @storage
+        DIG 3;      # @storage : contract (pair string (pair timestamp nat)) : string : @parameter%get
+        DUP;        # @storage : @storage : contract (pair string (pair timestamp nat)) : string : @parameter%get
+        DUG 4;      # @storage : contract (pair string (pair timestamp nat)) : string : @parameter%get : @storage
+        CADR;       # big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : contract (pair string (pair timestamp nat)) : string : @parameter%get : @storage
+        DIG 2;      # string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : contract (pair string (pair timestamp nat)) : @parameter%get : @storage
+        DUP;        # string : string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : contract (pair string (pair timestamp nat)) : @parameter%get : @storage
+        DUG 3;      # string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : contract (pair string (pair timestamp nat)) : string : @parameter%get : @storage
+        MEM;        # bool : contract (pair string (pair timestamp nat)) : string : @parameter%get : @storage
         IF
           {
-            DIG 2;      # @parameter%get : contract (pair string nat) : string : @storage
-            DROP;       # contract (pair string nat) : string : @storage
+            DIG 2;      # @parameter%get : contract (pair string (pair timestamp nat)) : string : @storage
+            DROP;       # contract (pair string (pair timestamp nat)) : string : @storage
           }
           {
-            UNIT;       # unit : contract (pair string nat) : string : @parameter%get : @storage
+            UNIT;       # unit : contract (pair string (pair timestamp nat)) : string : @parameter%get : @storage
             FAILWITH;   # FAILED
-          }; # contract (pair string nat) : string : @storage
-        NIL operation; # list operation : contract (pair string nat) : string : @storage
-        SWAP;       # contract (pair string nat) : list operation : string : @storage
-        PUSH mutez 0; # mutez : contract (pair string nat) : list operation : string : @storage
-        DIG 4;      # @storage : mutez : contract (pair string nat) : list operation : string
-        DUP;        # @storage : @storage : mutez : contract (pair string nat) : list operation : string
-        DUG 5;      # @storage : mutez : contract (pair string nat) : list operation : string : @storage
-        CADR;       # big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract (pair string nat) : list operation : string : @storage
-        DIG 4;      # string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract (pair string nat) : list operation : @storage
-        DUP;        # string : string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract (pair string nat) : list operation : @storage
-        DUG 5;      # string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract (pair string nat) : list operation : string : @storage
-        GET;        # option (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract (pair string nat) : list operation : string : @storage
+          }; # contract (pair string (pair timestamp nat)) : string : @storage
+        NIL operation; # list operation : contract (pair string (pair timestamp nat)) : string : @storage
+        SWAP;       # contract (pair string (pair timestamp nat)) : list operation : string : @storage
+        PUSH mutez 0; # mutez : contract (pair string (pair timestamp nat)) : list operation : string : @storage
+        DIG 4;      # @storage : mutez : contract (pair string (pair timestamp nat)) : list operation : string
+        DUP;        # @storage : @storage : mutez : contract (pair string (pair timestamp nat)) : list operation : string
+        DUG 5;      # @storage : mutez : contract (pair string (pair timestamp nat)) : list operation : string : @storage
+        CADR;       # big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract (pair string (pair timestamp nat)) : list operation : string : @storage
+        DIG 4;      # string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract (pair string (pair timestamp nat)) : list operation : @storage
+        DUP;        # string : string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract (pair string (pair timestamp nat)) : list operation : @storage
+        DUG 5;      # string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract (pair string (pair timestamp nat)) : list operation : string : @storage
+        GET;        # option (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : mutez : contract (pair string (pair timestamp nat)) : list operation : string : @storage
         IF_SOME
           {}
           {
-            UNIT;       # unit : mutez : contract (pair string nat) : list operation : string : @storage
+            UNIT;       # unit : mutez : contract (pair string (pair timestamp nat)) : list operation : string : @storage
             FAILWITH;   # FAILED
-          }; # @some : mutez : contract (pair string nat) : list operation : string : @storage
-        CAAR;       # nat : mutez : contract (pair string nat) : list operation : string : @storage
-        DIG 4;      # string : nat : mutez : contract (pair string nat) : list operation : @storage
-        PAIR;       # pair string nat : mutez : contract (pair string nat) : list operation : @storage
+          }; # @some : mutez : contract (pair string (pair timestamp nat)) : list operation : string : @storage
+        CAAR;       # nat : mutez : contract (pair string (pair timestamp nat)) : list operation : string : @storage
+        DIG 5;      # @storage : nat : mutez : contract (pair string (pair timestamp nat)) : list operation : string
+        DUP;        # @storage : @storage : nat : mutez : contract (pair string (pair timestamp nat)) : list operation : string
+        DUG 6;      # @storage : nat : mutez : contract (pair string (pair timestamp nat)) : list operation : string : @storage
+        CADR;       # big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : nat : mutez : contract (pair string (pair timestamp nat)) : list operation : string : @storage
+        DIG 5;      # string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : nat : mutez : contract (pair string (pair timestamp nat)) : list operation : @storage
+        DUP;        # string : string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : nat : mutez : contract (pair string (pair timestamp nat)) : list operation : @storage
+        DUG 6;      # string : big_map string (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : nat : mutez : contract (pair string (pair timestamp nat)) : list operation : string : @storage
+        GET;        # option (pair (pair (nat %computedPrice) (timestamp %lastUpdateTime)) (pair (pair %prices (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))) (pair %volumes (pair (int %first) (int %last)) (pair (map %saved int nat) (nat %sum))))) : nat : mutez : contract (pair string (pair timestamp nat)) : list operation : string : @storage
+        IF_SOME
+          {}
+          {
+            UNIT;       # unit : nat : mutez : contract (pair string (pair timestamp nat)) : list operation : string : @storage
+            FAILWITH;   # FAILED
+          }; # @some : nat : mutez : contract (pair string (pair timestamp nat)) : list operation : string : @storage
+        CADR;       # timestamp : nat : mutez : contract (pair string (pair timestamp nat)) : list operation : string : @storage
+        PAIR;       # pair timestamp nat : mutez : contract (pair string (pair timestamp nat)) : list operation : string : @storage
+        DIG 4;      # string : pair timestamp nat : mutez : contract (pair string (pair timestamp nat)) : list operation : @storage
+        PAIR;       # pair string (pair timestamp nat) : mutez : contract (pair string (pair timestamp nat)) : list operation : @storage
         TRANSFER_TOKENS; # operation : list operation : @storage
         CONS;       # list operation : @storage
       }


### PR DESCRIPTION
This PR adds a third piece of data to the `get` entrypoint, which returns the time of the latest candle used to compute the update. Client contracts may find this data useful to make assertions about the recency of their data. 

Specifically, this PR:
- Updates logic as described above
- Updates tests, including verifying the timestamp is returned as expected
- Runs `compile_smartpy.sh` to prove tests pass and produce a new `normalizer.tz` file. 

Additional considerations:
- This is technically a breaking change. We've already made a decision to break the API in #22 so this isn't introducing any additional pain. 

Future Tasks:
- If accepted, we'll need to cut a new version of `harbinger-lib` and `harbinger-cli` which export this new contract
- We should re-deploy the testnet / mainnet normalizers and update the posting infrastructure Blockscale is running
- We should have some comms strategy for community projects who might be prototyping with this data