### PR TITLE
import path fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+.smartpy_out/
+venv/

--- a/oracle.py
+++ b/oracle.py
@@ -1,6 +1,6 @@
 import smartpy as sp
 
-Harbinger = sp.import_script_from_url("file:common.py")
+Harbinger = sp.io.import_script_from_url("file:common.py")
 
 # Data type that represents a signed update to the Oracle.
 SignedOracleDataType = sp.TPair(sp.TSignature, Harbinger.OracleDataType)


### PR DESCRIPTION
seems smartpy moved this method to the `io` package. ran into an error when running the compile script.

progress, but output is now...

```
Running Tests Before Compilation
>> Testing Oracle 
[error] invalid flag usage: no_comment
[error] invalid flag usage: no_comment
[error] invalid flag usage: no_comment
[error] invalid flag usage: no_comment
[error] invalid flag usage: no_comment
[error] invalid flag usage: no_comment
[error] invalid flag usage: no_comment
[error] invalid flag usage: no_comment
[error] invalid flag usage: no_comment
```